### PR TITLE
Revert "Added possibility to open thumbnails links in lightbox"

### DIFF
--- a/app/views/attachments/_links.html.erb
+++ b/app/views/attachments/_links.html.erb
@@ -37,7 +37,7 @@
         <%=
           link_to image_tag(url_for(:controller => 'attachments', :action => 'thumbnail', :id => attachment)),
           {:controller => 'attachments', :action => 'show', :id => attachment, :filename => attachment.filename},
-          :class => 'lightbox', :rel => 'attachments', :title => "#{attachment.filename}#{ ('-' + attachment.description) unless attachment.description.blank? }", :data  => {:fancybox_type => 'iframe'}
+          :class => 'lightbox', :rel => 'attachments', :title => "#{attachment.filename}#{ ('-' + attachment.description) unless attachment.description.blank? }"
         %>
       </div>
     <% end %>


### PR DESCRIPTION
This reverts commit cb594a7b29b5ddf0f1646d4532b87e3f77dd1af7.

Fixes for large images, which do not resize to popup size (you have to scroll)