### PR TITLE
Fix scroll on click

### DIFF
--- a/assets/javascripts/lightbox.js
+++ b/assets/javascripts/lightbox.js
@@ -3,7 +3,12 @@ $(document).ready(function() {
 			prevEffect		: 'none',
 			nextEffect		: 'none',
 			openSpeed		: 400, 
-			closeSpeed		: 200
+			closeSpeed		: 200,
+			helpers: {
+				overlay: {
+					locked: false
+				}
+			}
 		});
 
     $("div.attachments a.pdf").fancybox({
@@ -16,6 +21,11 @@ $(document).ready(function() {
 			autoSize		: true,
 			iframe : {
 				preload: false
+			},
+			helpers: {
+				overlay: {
+					locked: false
+				}
 			}
 		});
 });

--- a/init.rb
+++ b/init.rb
@@ -7,7 +7,7 @@ Redmine::Plugin.register :redmine_lightbox2 do
   name 'Redmine Lightbox 2'
   author 'Tobias Fischer'
   description 'This plugin lets you preview image, pdf and swf attachments in a lightbox.'
-  version '0.1.3'
+  version '0.1.4-SNAPSHOT'
   url 'https://github.com/paginagmbh/redmine_lightbox2'
   requires_redmine :version => '2.6'
 end


### PR DESCRIPTION
As per my comment in paginagmbh/redmine_lightbox2#18, this PR implements the `helpers` option to lock content in place and prevent page scrolling when a FancyBox popup is activated. See [the docs](http://fancyapps.com/fancybox/#helpers) for more information.

I've also bumped the version for a dev snapshot, I'll leave it up to you (@tofi86) to confirm and release it in your own way. :)

So far, this has only been tested and confirmed working in Redmine 2.6.6.