### PR TITLE
Redmine 4.2 and Download attachments at once

### DIFF
--- a/app/views/attachments/_links.html.erb
+++ b/app/views/attachments/_links.html.erb
@@ -6,6 +6,11 @@
               :title => l(:label_edit_attachments),
               :class => 'icon-only icon-edit'
              ) if options[:editable] %>
+  <%= link_to(l(:label_download_all_attachments),
+              container_attachments_download_path(container),
+              :title => l(:label_download_all_attachments),
+              :class => 'icon-only icon-download'
+             ) if attachments.size > 1 %>
 </div>
 
 <table>


### PR DESCRIPTION
Redmine 4.2 added "Download All Attachments Button" which was not presented on the UI.